### PR TITLE
Handle Dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,16 @@ uv run powershell ./build_exe.ps1
 ```
 
 Your executable will be in dist/.
+
+### How to add dependencies
+
+Copy your MSIX file and dependencies into root of this repo, then run the preparation step
+
+```ps
+uv run python extract_msix_data.py path_to_your_msix_file path_to_dependency path_to_second_dependency ...
+```
+
+The packages will be installed in reverse order with the last one specified installed first, until the
+main package (first argument) is installed last.
+
+There is no tested limit on the number of dependencies.

--- a/build_exe.ps1
+++ b/build_exe.ps1
@@ -1,6 +1,16 @@
-$path = python -c "import pickle; print(pickle.load(open('extracted/data.pkl', 'rb')).package_path)"
-$basename = [System.IO.Path]::GetFileNameWithoutExtension($path)
+# Get picked data to get name and icon
+$paths_py = python -c "import pickle; m = pickle.load(open('extracted/data.pkl', 'rb')); print([a.package_path for a in m])"
+$paths_py_doublequotes = $paths_py -replace "'", '"'
+$paths_json = $paths_py_doublequotes | ConvertFrom-Json
+$main_app_path = $paths_json[0]
+$addDataArgs = $paths_json | ForEach-Object { "--add-data `'$($_):.`'" }
+$addDataString = $addDataArgs -replace "`r?`n", ""
+
+$basename = [System.IO.Path]::GetFileNameWithoutExtension($main_app_path)
 $pathexe = $basename + ".exe"
-$icon = python -c "import pickle; print(pickle.load(open('extracted/data.pkl', 'rb')).icon_path)"
-$add_data_msix_path = $path + ":."
-pyinstaller .\src\msix_global_installer\app.py --add-data 'extracted:extracted' --add-data "$add_data_msix_path" --onefile --name $pathexe --icon $icon --noconsole
+$icon = python -c "import pickle; print(pickle.load(open('extracted/data.pkl', 'rb'))[0].icon_path)"
+
+# Build command
+# This only works when first stored as a string - some powershell string issue for the add-data commands
+$command_str = "pyinstaller .\src\msix_global_installer\app.py --add-data 'extracted:extracted' $addDataString --onefile --name $pathexe --icon $icon --noconsole"
+Invoke-Expression $command_str

--- a/extract_msix_data.py
+++ b/extract_msix_data.py
@@ -9,6 +9,12 @@ from msix_global_installer import msix, pickler, image
 import sys
 import pathlib
 
+
+def get_metadata(paths: list[str]) -> list[msix.MsixMetadata]:
+    """Get the metadata from a list of items."""
+    return [msix.get_msix_metadata(path) for path in paths]
+
+
 path = sys.argv[1]
 print("Extracting data from %s" % path)
 
@@ -18,6 +24,11 @@ if not data_output_path.exists():
 data_file = data_output_path / "data.pkl"
 
 metadata = msix.get_msix_metadata(path, data_output_path)
+dependency_paths = sys.argv[2:]
+dependency_metadata = []
+if dependency_paths:
+    dependency_metadata = get_metadata(paths=dependency_paths)
+all_metadata = [metadata] + dependency_metadata
 
 # Scale the image, save and add to metadata
 scaled_image = image.scale_image(metadata.icon_path, 100, 100)
@@ -27,4 +38,4 @@ scaled_image_path = pathlib.Path(metadata.icon_path.parent) / pathlib.Path(
 image.save_image(scaled_image, scaled_image_path)
 metadata.scaled_icon_path = scaled_image_path
 
-pickler.save_metadata(data_file_path=data_file, metadata=metadata)
+pickler.save_metadata(data_file_path=data_file, metadata_list=all_metadata)

--- a/src/msix_global_installer/pickler.py
+++ b/src/msix_global_installer/pickler.py
@@ -3,13 +3,13 @@ import pickle
 from msix_global_installer import msix
 
 
-def save_metadata(data_file_path: pathlib.Path, metadata: msix.MsixMetadata):
+def save_metadata(data_file_path: pathlib.Path, metadata_list: list[msix.MsixMetadata]):
     """Save MSIX metadata to a pickle file."""
     with open(data_file_path, "wb") as file:
-        pickle.dump(metadata, file)
+        pickle.dump(metadata_list, file)
 
 
-def load_metadata(data_file_path: pathlib.Path) -> msix.MsixMetadata:
+def load_metadata(data_file_path: pathlib.Path) -> list[msix.MsixMetadata]:
     """Load MSIX metadata from a pickle file."""
     with open(data_file_path, "rb") as file:
         return pickle.load(file)

--- a/tests/test_msix.py
+++ b/tests/test_msix.py
@@ -10,7 +10,7 @@ class TestMsix:
         """Test we get the required metadata from a given test file."""
         path = pathlib.Path("tests/TestMsixPackage.msix")
         dir = tmpdir
-        data = msix.get_msix_metadata(path, output_path=dir)
+        data = msix.get_msix_metadata(path, output_icon_path=dir)
         assert data.package_name == "MyEmployees"
         assert data.version == "9.0.0.0"
         assert data.publisher == "Contoso Corporation"


### PR DESCRIPTION
Allow applications to package MSIX dependencies - such as when installing on a Windows 11 IoT device that needs MSIX dependencies. 